### PR TITLE
feat(): defaultEdgeLines 调整为markers分别配置起始，终点箭头

### DIFF
--- a/bricks/diagram/docs/eo-display-canvas.md
+++ b/bricks/diagram/docs/eo-display-canvas.md
@@ -61,10 +61,10 @@
                 strokeColor:"pink",
                 animate:{
                   useAnimate: true,
-                  duration: 4 
-                } 
+                  duration: 4
+                }
               }
-            }, 
+            },
             {
               type: "edge",
               source: "X",
@@ -74,8 +74,8 @@
                 showStartArrow: true,
                 strokeColor:"blue",
                 animate:{
-                  useAnimate: true 
-                } 
+                  useAnimate: true
+                }
               }
             },
             {
@@ -108,7 +108,7 @@
                 height: 60,
               }
             }))
-          ).concat([ 
+          ).concat([
             {
               type: "decorator",
               id: "text-1",
@@ -120,7 +120,7 @@
                 height: 20,
                 text: "Hello!"
               },
-            },  
+            },
           ])
         %>
     - name: activeTarget
@@ -163,6 +163,12 @@
                 showStartArrow: <% DATA.edge?.data?.showStartArrow %>
                 strokeWidth: <% DATA.edge?.data?.strokeWidth %>
                 animate: <% DATA.edge?.data?.animate %>
+                showStartArrow: true
+                markers:
+                  - placement: end
+                    type: circle
+                  - placement: start
+                    type: arrow
             cells: <% CTX.initialCells %>
           events:
             activeTarget.change:

--- a/bricks/diagram/docs/eo-draw-canvas.md
+++ b/bricks/diagram/docs/eo-draw-canvas.md
@@ -339,6 +339,12 @@
                 dashed: true
               - if: <% !DATA.edge.data?.virtual %>
                 dotted: true
+                showStartArrow: true
+                markers:
+                  - placement: end
+                    type: circle
+                  - placement: start
+                    type: arrow
             cells: <% CTX.initialCells %>
             lineConnector: true
             lineSettings:

--- a/bricks/diagram/src/display-canvas/index.spec.tsx
+++ b/bricks/diagram/src/display-canvas/index.spec.tsx
@@ -499,6 +499,8 @@ describe("eo-display-canvas", () => {
         target: "c",
         data: {
           dotted: true,
+          showStartArrow: true,
+          showEndArrow: false,
         },
       },
       {
@@ -507,10 +509,17 @@ describe("eo-display-canvas", () => {
         target: "a",
         data: {
           dashed: true,
-          showStartArrow: true,
-          showEndArrow: false,
           strokeColor: "blue",
-          markerType: "circle",
+          markers: [
+            {
+              type: null,
+              placement: "start",
+            },
+            {
+              type: "circle",
+              placement: "end",
+            },
+          ],
           strokeWidth: 5,
           parallelGap: 5,
           animate: {
@@ -550,7 +559,7 @@ describe("eo-display-canvas", () => {
         dashed: "<% DATA.edge?.data?.dashed %>",
         dotted: "<% DATA.edge?.data?.dotted %>",
         strokeColor: "<% DATA.edge?.data?.strokeColor %>",
-        markerType: "<% DATA.edge?.data?.markerType %>",
+        markers: "<% DATA.edge?.data?.markers %>",
         showStartArrow: "<% DATA.edge?.data?.showStartArrow %>",
         showEndArrow: "<% DATA.edge?.data?.showEndArrow %>",
         strokeWidth: "<% DATA.edge?.data?.strokeWidth %>",
@@ -570,7 +579,7 @@ describe("eo-display-canvas", () => {
       [...element.shadowRoot!.querySelectorAll("marker path")].map(
         (markerPath) => (markerPath as SVGPathElement).getAttribute("stroke")
       )
-    ).toEqual(["gray", "red"]);
+    ).toEqual(["gray", "red", "blue"]);
     expect(element.shadowRoot!.querySelectorAll("path.dotted").length).toBe(1);
     expect(element.shadowRoot!.querySelectorAll("marker circle").length).toBe(
       1

--- a/bricks/diagram/src/draw-canvas/EdgeComponent.tsx
+++ b/bricks/diagram/src/draw-canvas/EdgeComponent.tsx
@@ -7,6 +7,8 @@ import { curveLine } from "../diagram/lines/curveLine";
 import { getSmartLinePoints } from "../shared/canvas/processors/getSmartLinePoints";
 import { findNodeOrAreaDecorator } from "./processors/findNodeOrAreaDecorator";
 import { useHoverStateContext } from "./HoverStateContext";
+import { getMarkers } from "../shared/canvas/useLineMarkers";
+import { LineMarkerConf } from "../diagram/interfaces";
 
 export interface EdgeComponentProps {
   edge: EdgeCell;
@@ -110,6 +112,17 @@ export function EdgeComponent({
     return null;
   }
 
+  let markerStart: string | undefined;
+  let markerEnd: string | undefined;
+  const lineMarkers: LineMarkerConf[] = getMarkers(lineConf);
+  for (const marker of lineMarkers) {
+    if (marker.placement === "start") {
+      markerStart = lineConf.$markerStartUrl;
+    } else {
+      markerEnd = lineConf.$markerEndUrl;
+    }
+  }
+
   return (
     <>
       <path
@@ -137,8 +150,8 @@ export function EdgeComponent({
         fill="none"
         stroke={lineConf.strokeColor}
         strokeWidth={lineConf.strokeWidth}
-        markerStart={lineConf.showStartArrow ? lineConf.$markerUrl : ""}
-        markerEnd={lineConf.showEndArrow ? lineConf.$markerUrl : ""}
+        markerStart={markerStart}
+        markerEnd={markerEnd}
       />
       <path className="line-active-bg" d={line} fill="none" />
     </>

--- a/bricks/diagram/src/draw-canvas/EditingLineComponent.tsx
+++ b/bricks/diagram/src/draw-canvas/EditingLineComponent.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import classNames from "classnames";
 import type { ComputedLineConnecterConf } from "./interfaces";
 import type {
+  LineMarkerConf,
   NodePosition,
   PositionTuple,
   TransformLiteral,
@@ -13,6 +14,7 @@ import {
   getEditingLinePoints,
   getNewLineVertices,
 } from "../shared/canvas/processors/getEditingLinePoints";
+import { getMarkers } from "../shared/canvas/useLineMarkers";
 
 export interface EditingLineComponentProps {
   transform: TransformLiteral;
@@ -153,6 +155,16 @@ export function EditingLineComponent({
       1
     );
   }, [connectLineTo, hoverState, lineEditorState]);
+  let markerStart: string | undefined;
+  let markerEnd: string | undefined;
+  const lineMarkers: LineMarkerConf[] = getMarkers(options);
+  for (const marker of lineMarkers) {
+    if (marker.placement === "start") {
+      markerStart = options.$editingStartMarkerUrl;
+    } else {
+      markerEnd = options.$editingEndMarkerUrl;
+    }
+  }
 
   return (
     <path
@@ -162,8 +174,8 @@ export function EditingLineComponent({
       d={line}
       fill="none"
       stroke={options.editingStrokeColor}
-      markerStart={options.showStartArrow ? options.$editingMarkerUrl : ""}
-      markerEnd={options.showEndArrow ? options.$editingMarkerUrl : ""}
+      markerStart={markerStart}
+      markerEnd={markerEnd}
     />
   );
 }

--- a/bricks/diagram/src/draw-canvas/SmartConnectLineComponent.tsx
+++ b/bricks/diagram/src/draw-canvas/SmartConnectLineComponent.tsx
@@ -2,10 +2,15 @@
 import React, { useEffect, useMemo, useState } from "react";
 import classNames from "classnames";
 import type { ComputedLineConnecterConf, LineSettings } from "./interfaces";
-import type { PositionTuple, TransformLiteral } from "../diagram/interfaces";
+import type {
+  LineMarkerConf,
+  PositionTuple,
+  TransformLiteral,
+} from "../diagram/interfaces";
 import { curveLine } from "../diagram/lines/curveLine";
 import { useHoverStateContext } from "./HoverStateContext";
 import { getConnectLinePoints } from "../shared/canvas/processors/getConnectLinePoints";
+import { getMarkers } from "../shared/canvas/useLineMarkers";
 
 export interface SmartConnectLineComponentProps {
   transform: TransformLiteral;
@@ -68,6 +73,17 @@ export function SmartConnectLineComponent({
     );
   }, [connectLineTo, hoverState, smartConnectLineState, options, lineSettings]);
 
+  let markerStart: string | undefined;
+  let markerEnd: string | undefined;
+  const lineMarkers: LineMarkerConf[] = getMarkers(options);
+  for (const marker of lineMarkers) {
+    if (marker.placement === "start") {
+      markerStart = options.$markerStartUrl;
+    } else {
+      markerEnd = options.$markerEndUrl;
+    }
+  }
+
   return (
     <path
       className={classNames("connect-line", {
@@ -77,8 +93,8 @@ export function SmartConnectLineComponent({
       fill="none"
       stroke={options.strokeColor}
       strokeWidth={options.strokeWidth}
-      markerStart={options.showStartArrow ? options.$markerUrl : ""}
-      markerEnd={options.showEndArrow ? options.$markerUrl : ""}
+      markerStart={markerStart}
+      markerEnd={markerEnd}
     />
   );
 }

--- a/bricks/diagram/src/draw-canvas/interfaces.ts
+++ b/bricks/diagram/src/draw-canvas/interfaces.ts
@@ -3,6 +3,7 @@ import type { SimulationLinkDatum, SimulationNodeDatum } from "d3-force";
 import type { ResizeCellPayload } from "./reducers/interfaces";
 import type {
   CurveType,
+  LineMarkerConf,
   LineMarkerType,
   NodePosition,
   PartialRectTuple,
@@ -115,7 +116,8 @@ export interface LineAnimate {
 }
 
 export interface ComputedEdgeLineConf extends Required<BaseEdgeLineConf> {
-  $markerUrl: string;
+  $markerStartUrl: string;
+  $markerEndUrl: string;
 }
 
 export interface BaseEdgeLineConf {
@@ -127,8 +129,14 @@ export interface BaseEdgeLineConf {
   strokeColor?: string;
   interactStrokeWidth?: number;
   parallelGap?: number;
-  markerType?: LineMarkerType;
+  markers?: LineMarkerConf[];
+  /**
+   * 已废弃，使用markers代替，配置了对应的箭头测则显示
+   */
   showStartArrow?: boolean;
+  /**
+   * 已废弃
+   */
   showEndArrow?: boolean;
   animate?: LineAnimate;
 }
@@ -147,7 +155,8 @@ export type LineConnecterConf = Pick<
 
 export type ComputedLineConnecterConf = ComputedEdgeLineConf & {
   editingStrokeColor: string;
-  $editingMarkerUrl: string;
+  $editingStartMarkerUrl: string;
+  $editingEndMarkerUrl: string;
 };
 
 export type ActiveTarget = ActiveTargetOfSingular | ActiveTargetOfMulti;


### PR DESCRIPTION
Closes CMDB_CONSUME-426

## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查

Git 提交信息将决定包的版本发布及自动生成的 CHANGELOG，请检查工作内容与提交信息是否相符，并在以下每组选项中都依次确认。

> 破坏性变更是针对于下游使用者而言，可以通过本次改动对下游使用者的影响来识别变更类型：
>
> - 下游使用者不做任何改动，仍可以正常工作时，那么它属于普通变更。
> - 反之，下游使用者不做改动就无法正常工作时，那么它属于破坏性变更。
>
> 例如，构件修改了一个属性名，小产品 Storyboard 中需要使用新属性名才能工作，那么它就是破坏性变更。
> 又例如，构件还没有任何下游使用者，那么它的任何变更都是普通变更。

### 破坏性变更：

- [ ] ⚠️ 本次 MR 包含**破坏性变更**的提交，请继续确认以下所有选项：
- [ ] 没有更好的兼容方案，必须做破坏性变更。
- [ ] 使用了 `feat` 作为提交类型。
- [ ] 标注了 `BREAKING CHANGE: 你的变更说明`。
- [ ] 同时更新了本仓库中所有下游使用者的调用。
- [ ] 同时更新了本仓库中所有下游使用者对该子包的依赖为即将发布的 major 版本。
- [ ] 同时为其它仓库的 Migrating 做好了准备，例如文档或批量改动的方法。
- [ ] 手动验证过破坏性变更在 Migrate 后可以正常工作。
- [ ] 破坏性变更所在的提交没有意外携带其它子包的改动。

### 新特性：

- [x] 本次 MR 包含新特性的提交，且该提交不带有破坏性变更，并使用了 `feat` 作为提交类型。
- [x] 给新特性添加了单元测试。
- [x] 手动验证过新特性可以正常工作。

### 问题修复：

- [ ] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [ ] 给问题修复添加了单元测试。
- [ ] 手动验证过问题修复得到解决。

### 杂项工作：

即所有对下游使用者无任何影响、且没有必要显示在 CHANGELOG 中的改动，例如修改注释、测试用例、开发文档等：

- [ ] 本次 MR 包含杂项工作的提交，且该提交不带有问题修复、新特性或破坏性变更，并使用了 `chore`, `docs`, `test` 等作为提交类型。

<!-- ## 简单描述

<!-- 我在这个 MR 里都做了哪些工作？!-->

<!-- ## Todo

<!-- 我还有哪些事情没做？!-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 增强了 `eo-display-canvas` 和 `eo-draw-canvas` 组件的边缘和节点管理功能。
	- 新增 `lineSettings` 属性，允许自定义边缘样式（如虚线或点线）。
	- 改进了拖放功能，支持节点和装饰器的拖放操作。
	- 更新了上下文菜单，提供基于目标单元类型的操作选项。
	- 所有示例中的边缘属性处理保持一致性，新增 `showStartArrow` 和 `markers` 属性。
	- 引入了新的帮助函数 `getMarkers`，增强了标记配置的灵活性。
	- 动态更新用户交互后的上下文，提升用户体验。

- **Bug 修复**
	- 优化了边缘属性的处理，确保在多个示例中保持一致性。

- **文档**
	- 更新了相关文档，以反映新添加的属性和功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->